### PR TITLE
Introduce `NonDecreasingList a` and `HomoList a` to denote lists whos…

### DIFF
--- a/src/GradedList.hs
+++ b/src/GradedList.hs
@@ -1,40 +1,134 @@
 module GradedList (
-    Grading,
     Graded,
     grading,
+    NonDecreasingList,
+    unNDecList,
+    nDecList,
+    HomoList,
+    unHomoList,
+    homoList,
     distributeLists,
     distributeGradedLists,
     groupByGrading,
 ) where
 
--- a list of elements with the same grading
-type Grading t = [t]
-
 -- | Use @Integer@ since it can be converted to any numeric type using @fromInteger@.
 class Graded t where
     grading :: t -> Integer
 
--- | Used for testing purposes.
-instance Graded Int where
-  grading 0 = 0
-  grading n = 1 + (grading $ abs_n `div` 10)
-    where
-      abs_n = abs n
+{- | @Integer@ is used to generate basis elements for testing @Symbolics.hs@. The grading of an integer is the number of digits in its absolute value.
 
+Example:
+
+>>> grading 123
+3
+>>> grading (-123)
+3
+-}
 instance Graded Integer where
-  grading 0 = 0
-  grading n = 1 + (grading $ abs_n `div` 10)
-    where
-      abs_n = abs n
+    grading 0 = 0
+    grading n = 1 + (grading $ abs_n `div` 10)
+      where
+        abs_n = abs n
 
+-- | @Char@ can be useful to denote variables like @'x', 'y', 'z'@ when using @Symbolics.hs@. The grading of a character is 1.
 instance Graded Char where
-  grading _ = 1
+    grading _ = 1
 
-instance Graded a => Graded [a] where
-  grading [] = 0
-  grading (h : t) = (grading h) + (grading t)
+{- | The Haskell list structure is used to represent the free product in @Symbolics.hs@. The grading of a list is the sum of the gradings of its elements.
 
--- Graded distribution of lists graded by position
+Example:
+
+>>> grading [1, 2, 3]
+3
+>>> grading [[1, 2], [3, 4]]
+4
+-}
+instance (Graded a) => Graded [a] where
+    grading [] = 0
+    grading (h : t) = (grading h) + (grading t)
+
+-- | A list in which the gradings of the elements is non-decreasing.
+newtype NonDecreasingList a = NDecList {unNDecList :: [a]} deriving (Eq)
+
+instance (Show a) => Show (NonDecreasingList a) where
+    show (NDecList l) = "NonDecreasingList " ++ show l
+
+instance Functor NonDecreasingList where
+    fmap f (NDecList l) = NDecList $ map f l
+
+instance Foldable NonDecreasingList where
+    foldr f z (NDecList l) = foldr f z l
+
+{- | Construct a graded list by checking that the grading is non-decreasing.
+
+Example:
+
+>>> nDecList [1, 10, 10, 100]
+NonDecreasingList [1,10,10,100]
+>>> nDecList [1, 10, 100, 10]
+NonDecreasingList [1,10*** Exception: The list given to @gradedList@ is not graded.
+...
+-}
+nDecList :: (Graded a) => [a] -> NonDecreasingList a
+nDecList [] = NDecList []
+nDecList [x] = NDecList [x]
+nDecList (x : y : t) =
+    if (grading x) <= (grading y)
+        then (ndAppend x $ nDecList (y : t))
+        else error "The list given to @gradedList@ is not graded."
+  where
+    ndAppend x' = NDecList . (x' :) . unNDecList
+
+-- | A list in which all elements have the same grading.
+newtype HomoList a = HomoList {unHomoList :: [a]} deriving (Eq)
+
+instance (Show a) => Show (HomoList a) where
+    show (HomoList l) = "HomoList " ++ show l
+
+instance Functor HomoList where
+    fmap f (HomoList l) = HomoList $ map f l
+
+instance Foldable HomoList where
+    foldr f z (HomoList l) = foldr f z l
+
+{- | Construct a grading list by checking that the gradings of the elements are the same.
+
+Example:
+
+>>> homoList [1, 2, 3, 4]
+HomoList [1,2,3,4]
+>>> homoList [1, 2, 3, 10]
+HomoList [1,2*** Exception: The elements of the list given to @homoList@ have different gradings.
+...
+-}
+homoList :: (Graded a) => [a] -> HomoList a
+homoList [] = HomoList []
+homoList [x] = HomoList [x]
+homoList (x : y : t) =
+    if (grading x) == (grading y)
+        then (homoAppend x $ homoList (y : t))
+        else error "The elements of the list given to @homoList@ have different gradings."
+  where
+    homoAppend x' = HomoList . (x' :) . unHomoList
+
+-- | Groups the elements of a non-decreasing list by their grading. With the smallest grading given by @k@.
+groupByGradingWith :: (Graded a) => Integer -> NonDecreasingList a -> [HomoList a]
+groupByGradingWith _ (NDecList []) = []
+groupByGradingWith k (NDecList l) =
+    ( (\(g, t) -> (homoList g) : (groupByGradingWith (k + 1) $ NDecList t)) $
+        span (\x -> (grading x) == k) l
+    )
+
+{- | Same as @groupByGradingWith@ but uses the grading of the elements and starts with grading @0@.
+
+Example:
+
+>>> groupByGrading $ nDecList [3, 1, 2, 10, 10, 12, 20, 201, 200]
+[HomoList [],HomoList [3,1,2],HomoList [10,10,12,20],HomoList [201,200]]
+-}
+groupByGrading :: (Graded a) => NonDecreasingList a -> [HomoList a]
+groupByGrading = groupByGradingWith 0
 
 data Tree_ a = T_ [a] [Tree_ a] | Empty_ deriving (Show)
 
@@ -66,7 +160,7 @@ getElementsFromLevel _ Empty_ = []
 getElementsFromLevel 0 (T_ el _) = [el]
 getElementsFromLevel i (T_ _ subtrees) = concat $ map (getElementsFromLevel (i - 1)) subtrees
 
-_flattenTree :: (Eq a) => Tree_ a -> [[[a]]]
+_flattenTree :: Eq a => Tree_ a -> [[[a]]]
 _flattenTree Empty_ = []
 _flattenTree tree_ = takeWhile (/= []) $ map (\i -> getElementsFromLevel i tree_) [0 ..]
 
@@ -79,10 +173,10 @@ Example:
 >>> distributeLists [[1, 2], [11, 12], [21, 22]]
 [[1,11,21],[2,11,21],[1,12,21],[1,11,22],[2,12,21],[2,11,22],[1,12,22],[2,12,22]]
 -}
-distributeLists :: (Eq a) => [[a]] -> [[a]]
+distributeLists :: Eq a => [[a]] -> [[a]]
 distributeLists = concat . _flattenTree . (_buildTree 1)
 
-{- | The same as @distributeLists@ but it groups the resulting terms by the sums of their indices. It works in the following way: 
+{- | The same as @distributeLists@ but it groups the resulting terms by the sums of their indices. It works in the following way:
 @distributeLists [[a_1, a_2, a_3], [b_1, b_2], [c_1, c_2]]@ will return:
 @[[[a_1,b_1,c_1]],[[a_2,b_1,c_1],[a_1,b_2,c_1],[a_1,b_1,c_2]],[[a_3,b_1,c_1],[a_2,b_2,c_1],[a_2,b_1,c_2],[a_1,b_2,c_2]],[[a_3,b_2,c_1],[a_3,b_1,c_2],[a_2,b_2,c_2]],[[a_3,b_2,c_2]]]@.
 
@@ -91,22 +185,5 @@ Example:
 >>> distributeGradedLists [[1, 2, 3], [11, 12], [21, 22]]
 [[[1,11,21]],[[2,11,21],[1,12,21],[1,11,22]],[[3,11,21],[2,12,21],[2,11,22],[1,12,22]],[[3,12,21],[3,11,22],[2,12,22]],[[3,12,22]]]
 -}
-distributeGradedLists :: (Eq a) => [[a]] -> [[[a]]]
+distributeGradedLists :: Eq a => [[a]] -> [[[a]]]
 distributeGradedLists = _flattenTree . (_buildTree 1)
-
--- break a graded list into the list of gradings
-groupByGrading :: (Graded a, Show a) => [a] -> [Grading a]
-groupByGrading = groupByGradingWith 0 (fromInteger . grading)
-
-groupByGradingWith :: Show a => Int -> (a -> Int) -> [a] -> [Grading a]
-groupByGradingWith _ _ [] = []
-groupByGradingWith k f l@(h : _) =
-    if (f h) == k
-        then
-            ( (\(g, t) -> g : (groupByGradingWith (k + 1) f t)) $
-                span (\x -> (f x) == k) l
-            )
-        else if (f h) > k
-            then
-                [] : (groupByGradingWith (k + 1) f l)
-            else error $ "The list given to @groupByGradingWith@ is not graded, therefore, the grading of the element " ++ (show h) ++ " is less than the expected grading " ++ (show k) ++ "."

--- a/src/Symbolics.hs
+++ b/src/Symbolics.hs
@@ -59,6 +59,10 @@ import qualified Data.List as L (
  )
 import GradedList (
     Graded,
+    nDecList,
+    HomoList,
+    homoList,
+    unHomoList,
     distributeLists,
     distributeGradedLists,
     grading,
@@ -76,7 +80,7 @@ instance Arbitrary (Term Integer Integer) where
 
 >>> :{
 instance Arbitrary (Sum Integer Integer) where
-   arbitrary = fromListS <$> (arbitrary :: Gen [Term Integer Integer])
+   arbitrary = fromListS <$> homoList <$> (arbitrary :: Gen [Term Integer Integer])
 :}
 
 >>> :{
@@ -93,13 +97,9 @@ instance Arbitrary (PowerSeries Integer Integer) where
 
 class (Num k, Eq k, Show k) => Scalar k
 
-instance Scalar Int
-
 instance Scalar Integer
 
 class (Eq a, Show a, Graded a) => Basis a
-
-instance Basis Int
 
 instance Basis Integer
 
@@ -151,18 +151,19 @@ pattern t :+ s <- Sum t s
 -- | A sum is assumed to have a finite number of terms.
 data Sum k a = Sum (Term k a) (Sum k a) | Zero
 
-{- | Construct a sum from a list of terms. The list must be finite.
+{- | Construct a sum from a list of terms with the same grading. The list must be finite.
 
 Examples:
 
->>> fromListS [term 1 [1], term 1 [2], term 1 [1], term 1 [2]]
+>>> fromListS $ homoList [term 1 [1], term 1 [2], term 1 [1], term 1 [2]]
 2 *^ [1] + 2 *^ [2]
->>> fromListS [term 1 [1], term 1 [2], term 1 [1], term (-1) [2], term 1 [3]]
+>>> fromListS $ homoList [term 1 [1], term 1 [2], term 1 [1], term (-1) [2], term 1 [3]]
 2 *^ [1] + 1 *^ [3]
 -}
-fromListS :: (Scalar k, Basis a) => [Term k a] -> Sum k a
-fromListS [] = Zero
-fromListS (h : t) = h +: fromListS t
+fromListS :: (Scalar k, Basis a) => HomoList (Term k a) -> Sum k a
+fromListS l = case (unHomoList l) of
+                [] -> Zero
+                (h : t) -> h +: (fromListS $ homoList t)
 
 toListS :: Sum k a -> [Term k a]
 toListS Zero = []
@@ -182,14 +183,14 @@ infixr 7 +:
 
 Examples:
 
->>> (term 1 [1]) +: (fromListS [term 1 [1], term 1 [2]])
+>>> (term 1 [1]) +: (term 1 [1]) +: (term 1 [2]) +: Zero
 2 *^ [1] + 1 *^ [2]
->>> (term 1 [3]) +: (fromListS [term 1 [1], term 1 [2]])
+>>> (term 1 [3]) +: (term 1 [1]) +: (term 1 [2]) +: Zero
 1 *^ [3] + 1 *^ [1] + 1 *^ [2]
 
 Properties:
 
-prop> (lengthS $ t +: l) - 1 <= lengthS (l :: Sum Integer Integer)
+> (lengthS $ t +: l) - 1 <= lengthS (l :: Sum Integer Integer)
 -}
 (+:) :: (Scalar k, Basis a) => Term k a -> Sum k a -> Sum k a
 (+:) (Term 0 _) s = s
@@ -220,7 +221,7 @@ Examples:
 
 Properties:
 
-prop> s1 <> s2 == s2 <> (s1 :: Sum Integer Integer)
+> s1 <> s2 == s2 <> (s1 :: Sum Integer Integer)
 -}
 instance (Scalar k, Basis a) => Semigroup (Sum k a) where
     Zero <> s2 = s2
@@ -239,9 +240,9 @@ Examples:
 
 Properties:
 
-prop> invert s <> s == (mempty :: Sum Integer Integer)
-prop> s <> invert s == (mempty :: Sum Integer Integer)
-prop> invert (invert s) == (s :: Sum Integer Integer)
+> invert s <> s == (mempty :: Sum Integer Integer)
+> s <> invert s == (mempty :: Sum Integer Integer)
+> invert (invert s) == (s :: Sum Integer Integer)
 -}
 instance (Scalar k, Basis a) => Group (Sum k a) where
     invert Zero = Zero
@@ -256,7 +257,7 @@ True
 
 Properties:
 
-prop> (s1 == s2) == (s1 - s2 == (mempty :: Sum Integer Integer))
+> (s1 == s2) == (s1 - s2 == (mempty :: Sum Integer Integer))
 -}
 instance (Scalar k, Basis a) => Eq (Sum k a) where
     Zero == Zero = True
@@ -282,7 +283,7 @@ instance (Scalar k, Basis a) => Num (Sum k a) where
 
     negate = invert
 
-    a * b = fromListS $ map mconcat $ distributeLists ab_list
+    a * b = fromListS $ homoList $ map mconcat $ distributeLists ab_list
       where
         ab_list = [toListS a, toListS b]
 
@@ -332,7 +333,7 @@ Examples:
 
 Properties:
 
-prop> v1 <> v2 == (v2 <> v1 :: PowerSeries Integer Integer)
+> v1 <> v2 == (v2 <> v1 :: PowerSeries Integer Integer)
 -}
 instance (Scalar k, Basis a) => Semigroup (PowerSeries k a) where
     Empty <> ps = ps
@@ -350,7 +351,7 @@ _0
 
 Properties:
 
-prop> v <> mempty == (v :: PowerSeries Integer Integer)
+> v <> mempty == (v :: PowerSeries Integer Integer)
 -}
 
 instance (Scalar k, Basis a) => Monoid (PowerSeries k a) where
@@ -367,9 +368,9 @@ Examples:
 
 Properties:
 
-prop> v <> invert v == (mempty :: PowerSeries Integer Integer)
-prop> invert v <> v == (mempty :: PowerSeries Integer Integer)
-prop> invert (invert v) == (v :: PowerSeries Integer Integer)
+> v <> invert v == (mempty :: PowerSeries Integer Integer)
+> invert v <> v == (mempty :: PowerSeries Integer Integer)
+> invert (invert v) == (v :: PowerSeries Integer Integer)
 -}
 instance (Scalar k, Basis a) => Group (PowerSeries k a) where
     invert Empty = Empty
@@ -466,7 +467,7 @@ Examples:
 (1 *^ [1] + 1 *^ [2] + 1 *^ [3] + 1 *^ [4] + 1 *^ [5] + 1 *^ [6] + 1 *^ [7] + 1 *^ [8] + 1 *^ [9])_1 + (1 *^ [10])_2
 -}
 vectorG :: (Scalar k, Basis a) => [Term k a] -> PowerSeries k a
-vectorG = (fromListPS) . (map fromListS) . groupByGrading
+vectorG = (fromListPS) . (map fromListS) . groupByGrading . nDecList
 
 -- | The same as @vectorG@ but with basis elements instead of terms.
 basisVectorG :: (Scalar k, Basis a) => [[a]] -> PowerSeries k a
@@ -481,14 +482,14 @@ Examples:
 
 Properties:
 
-prop> mapV id v == (v :: PowerSeries Integer Integer)
+> mapV id v == (v :: PowerSeries Integer Integer)
 
 as well as @(mapV f (fmap g v)) == (map (f . g) v)@ and @(mapV f (v1 <> v2)) == ((mapV f v1) <> (mapV f v2))@.
 
 /__TODO:__ add property-tests for the last two properties above. Difficulty: how to generate functions that are monotonically increasing with respect to the grading? Use suchThat function of QuickCheck./
 -}
 mapV :: (Scalar k, Basis a, Basis b) => ([a] -> [b]) -> PowerSeries k a -> PowerSeries k b
-mapV f = vector . fromListS . (map $ fmap_ f) . terms
+mapV f = vector . fromListS . homoList . (map $ fmap_ f) . terms
   where fmap_ g t = term (scalar t) $ g $ basisElement t
 
 {- | The same as @fmap@, but the function @f@ must be monotonically increasing with respect to the grading, that is,
@@ -615,7 +616,7 @@ Examples:
 
 Properties:
 
-prop> lengthV v == length (terms v :: [Term Integer Integer])
+> lengthV v == length (terms v :: [Term Integer Integer])
 -}
 lengthV :: (Scalar k, Basis a) => PowerSeries k a -> Int
 lengthV = sum . (map lengthS) . toListPS
@@ -631,8 +632,8 @@ Examples:
 
 Properties:
 
-prop> takeWhileV (\_ -> True) v == (v :: PowerSeries Integer Integer)
-prop> takeWhileV (\_ -> False) v == (mempty :: PowerSeries Integer Integer)
+> takeWhileV (\_ -> True) v == (v :: PowerSeries Integer Integer)
+> takeWhileV (\_ -> False) v == (mempty :: PowerSeries Integer Integer)
 -}
 takeWhileV :: (Scalar k, Basis a) => (Term k a -> Bool) -> PowerSeries k a -> PowerSeries k a
 takeWhileV f = vectorG . (takeWhile f) . terms
@@ -646,11 +647,11 @@ Examples:
 
 Properties:
 
-prop> filterV (\_ -> True) v == (v :: PowerSeries Integer Integer)
-prop> filterV (\_ -> False) v == (mempty :: PowerSeries Integer Integer)
+> filterV (\_ -> True) v == (v :: PowerSeries Integer Integer)
+> filterV (\_ -> False) v == (mempty :: PowerSeries Integer Integer)
 -}
 filterV :: (Scalar k, Basis a) => (Term k a -> Bool) -> PowerSeries k a -> PowerSeries k a
-filterV f = fromListPS . (map $ fromListS . (filter f) . toListS) . toListPS
+filterV f = fromListPS . (map $ fromListS .homoList . (filter f) . toListS) . toListPS
 
 {- | Take the first @n@ terms from a vector.
 
@@ -661,7 +662,7 @@ Examples:
 
 Properties:
 
-prop> takeV (lengthV v) v == (v :: PowerSeries Integer Integer)
+> takeV (lengthV v) v == (v :: PowerSeries Integer Integer)
 prop> takeV 0 v == (mempty :: PowerSeries Integer Integer)
 -}
 takeV :: (Scalar k, Basis a) => Int -> PowerSeries k a -> PowerSeries k a
@@ -676,7 +677,7 @@ Examples:
 -}
 tensorCoproduct :: (Scalar k, Basis a) => [a] -> PowerSeries k [a]
 -- tensorCoproduct = product . (map (\b -> basisVector [([b],[]), ([],[b])]))
-tensorCoproduct = vector . fromListS . (map basisTerm) . listCoproduct
+tensorCoproduct = vector . fromListS . homoList . (map basisTerm) . listCoproduct
   where
     listCoproduct [] = [[[], []]] -- sum of tensor products of products
     listCoproduct (b : bs) =


### PR DESCRIPTION
…e elements have non-decreasing or homogeneous gradings. Now `Sum k a` requires its terms to be homogeneous, and `vectorG` requires them to be non-decreasing. This also clarified the type signatures of `groupByGrading`. Also added documentation and doctests to `GradedList.hs`. I didn't find a way to clarify the type signatures of `distributeLists` and `distributeGradedLists`, and decided to leave it for future work.